### PR TITLE
Change image to build FROM openshift/origin-v4.0:base in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY . .
 RUN git --version 
 RUN make build
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 
 COPY --from=builder /go/cluster-api-provider-ovirt/bin/manager /
 COPY --from=builder /go/cluster-api-provider-ovirt/bin/machine-controller-manager /


### PR DESCRIPTION
Images are expected to build from `registry.svc.ci.openshift.org/openshift/origin-v4.0:base`
See https://github.com/openshift/origin/blob/master/test/extended/operators/images.go#L110-L129
