### PR TITLE
Bug 1830852: Aadd network interfaces to machine spec and sync them

### DIFF
--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -67,6 +67,11 @@ type OvirtMachineProviderSpec struct {
 	// be used for and this effects the instance parameters.
 	// One of "desktop, server, high_performance"
 	VMType string `json:"type,omitempty"`
+
+	// NetworkInterfaces defines the list of the network interfaces of the VM.
+	// All network interfaces from the template are discarded and new ones will
+	// be created, unless the list is empty or nil
+	NetworkInterfaces []*NetworkInterface `json:"network_interfaces,omitempty"`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)
@@ -87,6 +92,12 @@ type CPU struct {
 type Disk struct {
 	// SizeGB size of the bootable disk in GiB.
 	SizeGB int64 `json:"size_gb"`
+}
+
+// NetworkInterface defines a VM network interface
+type NetworkInterface struct {
+	// VNICProfileID the id of the vNic profile
+	VNICProfileID string `json:"vnic_profile_id"`
 }
 
 // +genclient

--- a/pkg/cloud/ovirt/clients/machineservice.go
+++ b/pkg/cloud/ovirt/clients/machineservice.go
@@ -6,13 +6,8 @@ SPDX-License-Identifier: Apache-2.0
 package clients
 
 import (
-	"crypto/tls"
 	"fmt"
-	"io"
 	"math"
-	"net/http"
-	"net/url"
-	"os"
 	"time"
 
 	"github.com/openshift/cluster-api/pkg/util"
@@ -54,43 +49,6 @@ type SshKeyPair struct {
 
 type InstanceListOpts struct {
 	Name string `json:"name"`
-}
-
-func GetOvirtConnectionConf() (*ovirtsdk.ConnectionBuilder, error) {
-
-	//// expecting ovirt-config.yaml at ~/.ovirt/ovirt-config.yaml or at env VAR OVIRT_CONFIG
-	//file, err := os.Open("~/.ovirt/ovirt-config.yaml")
-
-	//getCredentialsSecret()
-	connectionBuilder := ovirtsdk.NewConnectionBuilder()
-
-	// just for debug
-	//klog.Infof("the ovirt config loaded is: %v", out)
-	engineUrl := "https://rgolan.usersys.redhat.com:8443/ovirt-engine/api"
-	connectionBuilder.
-		URL(engineUrl).
-		Username("admin@internal").
-		Password("123").
-		CAFile("")
-
-	client := http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}
-	certURL, _ := url.Parse(engineUrl)
-	certURL.Path = "ovirt-engine/services/pki-resource"
-	certURL.RawQuery = url.PathEscape("resource=ca-certificate&format=X509-PEM-CA")
-
-	resp, err := client.Get(certURL.String())
-	if err != nil || resp.StatusCode != http.StatusOK {
-		return connectionBuilder, fmt.Errorf("error downloading ovirt-engine certificate %s with status %v", err, resp)
-	}
-	defer resp.Body.Close()
-
-	file, err := os.Create("/tmp/ovirt-engine.ca")
-	if err != nil {
-		return connectionBuilder, fmt.Errorf("failed writing ovirt-engine certificate %s", err)
-	}
-	io.Copy(file, resp.Body)
-	connectionBuilder.CAFile(file.Name())
-	return connectionBuilder, nil
 }
 
 func NewInstanceServiceFromMachine(machine *machinev1.Machine, connection *ovirtsdk.Connection) (*InstanceService, error) {
@@ -192,7 +150,7 @@ func (is *InstanceService) InstanceCreate(
 		Tag(ovirtsdk.NewTagBuilder().Name(machine.Labels["machine.openshift.io/cluster-api-cluster"]).MustBuild()).
 		Send()
 	if err != nil {
-		klog.Errorf("Failed to add tag to  VM, skipping", err)
+		klog.Errorf("Failed to add tag to VM, skipping", err)
 	}
 
 	return &Instance{response.MustVm()}, nil

--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -35,7 +35,6 @@ import (
 const (
 	TimeoutInstanceCreate       = 5 * time.Minute
 	RetryIntervalInstanceStatus = 10 * time.Second
-	credentialsSecretName       = "ovirt-credentials"
 )
 
 type OvirtActuator struct {

--- a/pkg/cloud/ovirt/machine/instancestatus.go
+++ b/pkg/cloud/ovirt/machine/instancestatus.go
@@ -98,7 +98,7 @@ func (actuator *OvirtActuator) setMachineInstanceStatus(machine *machinev1.Machi
 	status.ObjectMeta.Annotations[InstanceStatusAnnotationKey] = ""
 
 	serializer := json.NewSerializer(json.DefaultMetaFactory, actuator.scheme, actuator.scheme, false)
-	b := []byte{}
+	var b []byte
 	buff := bytes.NewBuffer(b)
 	err := serializer.Encode((*machinev1.Machine)(status), buff)
 	if err != nil {


### PR DESCRIPTION
Handle interfaces, and create them if they are specified. The inherited
interfaces are delted and recreated.

This work enables specifiying the vNic profile id for a nic.
