### PR TITLE
BUG 1858400: [Performance] Lease refresh period for machine-api-controllers is too high, causes heavy writes to etcd at idle

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -74,7 +74,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		15*time.Second,
+		90*time.Second,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 


### PR DESCRIPTION
The machine-api-controller components are refreshing their lease more
than all other components combined. Bringing this to 90s each, will
decrease etcd writes at idle.

Relevant MAO PR - https://github.com/openshift/machine-api-operator/pull/649