### PR TITLE
Metrics port change to support updated MAO metrics integration

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	metricsAddr := flag.String(
 		"metrics-addr",
-		":8080",
+		":8081",
 		"The address the metric endpoint binds to.",
 	)
 


### PR DESCRIPTION
This change ensures compatibility with the ServiceMonitor resource
introduced in [1]

[1] https://github.com/openshift/machine-api-operator/pull/609

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>