### PR TITLE
BUG 1858400: [Performance] Lease refresh period for machine-api-controllers is too high, causes heavy writes to etcd at idle

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -40,6 +40,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 )
 
+// The default durations for the leader election operations.
+var (
+	leaseDuration = 120 * time.Second
+	renewDeadline = 110 * time.Second
+	retryPeriod   = 20 * time.Second
+)
+
 func main() {
 	klog.InitFlags(nil)
 
@@ -75,7 +82,7 @@ func main() {
 
 	leaderElectLeaseDuration := flag.Duration(
 		"leader-elect-lease-duration",
-		90*time.Second,
+		leaseDuration,
 		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
 	)
 
@@ -98,6 +105,9 @@ func main() {
 		LeaseDuration:           leaderElectLeaseDuration,
 		MetricsBindAddress:      *metricsAddr,
 		HealthProbeBindAddress:  *healthAddr,
+		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
+		RetryPeriod:   &retryPeriod,
+		RenewDeadline: &renewDeadline,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace


### PR DESCRIPTION
Prevent machine controllers from writing in etcd at idle too often by
setting 120s lease, 20s retry and 110s deadline on all renewals. Higher
values cause tests to flake.

Inspired by [openshift/cloud-credential-operator#231](https://github.com/openshift/cloud-credential-operator/pull/231)
Depends on [openshift/machine-api-operator#675](https://github.com/openshift/machine-api-operator/pull/675)

