### PR TITLE
Bug 1872080: Add Dockerfile.rhel to match build configuration in ocp-build-data

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,0 +1,36 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.svc.ci.openshift.org/ocp/builder:rhel-8-golang-openshift-4.6 AS builder
+
+ARG version
+ARG release
+
+LABEL   com.redhat.component="machine-api" \
+        name="cluster-api-provider-ovirt" \
+        version="$version" \
+        release="$release" \
+        architecture="x86_64" \
+        summary="cluster-api-provider-ovirt" \
+        maintainer="OCP RHV Team <ocprhvteam@redhat.com>"
+
+WORKDIR /go/cluster-api-provider-ovirt
+COPY . .
+
+
+RUN git --version
+RUN make build
+
+FROM registry.svc.ci.openshift.org/ocp/4.6:base
+
+COPY --from=builder /go/cluster-api-provider-ovirt/bin/manager /
+COPY --from=builder /go/cluster-api-provider-ovirt/bin/machine-controller-manager /


### PR DESCRIPTION
This change adds a new Dockerfile.rhel file to control builds that
target rhel. It is inspired by the automatically generated patches which
ensure that build files match what is in the
[ocp-build-data
repository](https://github.com/openshift/ocp-build-data/tree/openshift-4.6-rhel-8/images)
used for producing release artifacts.

After this change merges, the configuration files in
https://github.com/openshift/release/blob/master/ci-operator/config/openshift/cluster-api-provider-ovirt/openshift-cluster-api-provider-ovirt-master.yaml
and
https://github.com/openshift/ocp-build-data/blob/openshift-4.6/images/ose-ovirt-machine-controllers.yml
should be updated with the new dockerfile path.