### PR TITLE
Bug 1864352: Add leader election mechanism to release 4.5

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/klog"
@@ -40,8 +41,36 @@ import (
 func main() {
 	klog.InitFlags(nil)
 
-	watchNamespace := flag.String("namespace", "", "Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.")
-	metricsAddr := flag.String("metrics-addr", ":8080", "The address the metric endpoint binds to.")
+	watchNamespace := flag.String(
+		"namespace",
+		"",
+		"Namespace that the controller watches to reconcile machine-api objects. If unspecified, the controller watches for machine-api objects across all namespaces.",
+	)
+
+	metricsAddr := flag.String(
+		"metrics-addr",
+		":8080",
+		"The address the metric endpoint binds to.",
+	)
+
+	leaderElectResourceNamespace := flag.String(
+		"leader-elect-resource-namespace",
+		"",
+		"The namespace of resource object that is used for locking during leader election. If unspecified and running in cluster, defaults to the service account namespace for the controller. Required for leader-election outside of a cluster.",
+	)
+
+	leaderElect := flag.Bool(
+		"leader-elect",
+		false,
+		"Start a leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.",
+	)
+
+	leaderElectLeaseDuration := flag.Duration(
+		"leader-elect-lease-duration",
+		15*time.Second,
+		"The duration that non-leader candidates will wait after observing a leadership renewal until attempting to acquire leadership of a led but unrenewed leader slot. This is effectively the maximum duration that a leader can be stopped before it is replaced by another candidate. This is only applicable if leader election is enabled.",
+	)
+
 	flag.Parse()
 
 	log := logf.Log.WithName("ovirt-controller-manager")
@@ -55,7 +84,11 @@ func main() {
 
 	// Setup a Manager
 	opts := manager.Options{
-		MetricsBindAddress: *metricsAddr,
+		LeaderElection:          *leaderElect,
+		LeaderElectionNamespace: *leaderElectResourceNamespace,
+		LeaderElectionID:        "cluster-api-provider-ovirt-leader",
+		LeaseDuration:           leaderElectLeaseDuration,
+		MetricsBindAddress:      *metricsAddr,
 	}
 	if *watchNamespace != "" {
 		opts.Namespace = *watchNamespace


### PR DESCRIPTION
this change backports 2 commits to bring leader election support for 4.5

b076381586bdb8e3aab90ad1357ac06757afdb59
0bc31ed6588233aba1aa3d340ba1fd32d7bbee98