### PR TITLE
Bug 1883978: fix machine ProviderID

### DIFF
--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -338,7 +338,8 @@ func (actuator *OvirtActuator) reconcileProviderStatus(machine *machinev1.Machin
 
 func (actuator *OvirtActuator) reconcileProviderID(machine *machinev1.Machine, instance *clients.Instance) {
 	id := instance.MustId()
-	machine.Spec.ProviderID = &id
+	providerID := ovirt.ProviderIDPrefix + id
+	machine.Spec.ProviderID = &providerID
 
 	if machine.ObjectMeta.Annotations == nil {
 		machine.ObjectMeta.Annotations = make(map[string]string)

--- a/pkg/cloud/ovirt/providerIDcontroller/providerIDController.go
+++ b/pkg/cloud/ovirt/providerIDcontroller/providerIDController.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	"github.com/openshift/cluster-api-provider-ovirt/pkg/cloud/ovirt"
 	"github.com/openshift/cluster-api-provider-ovirt/pkg/cloud/ovirt/clients"
 )
 
@@ -57,7 +58,7 @@ func (r *providerIDReconciler) Reconcile(request reconcile.Request) (reconcile.R
 		return reconcile.Result{}, fmt.Errorf("failed getting VM from oVirt: %v", err)
 	}
 
-	node.Spec.ProviderID = fmt.Sprintf("ovirt://%s", id)
+	node.Spec.ProviderID = ovirt.ProviderIDPrefix + id
 	err = r.client.Update(context.Background(), &node)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed updating node %s: %v", node.Name, err)

--- a/pkg/cloud/ovirt/types.go
+++ b/pkg/cloud/ovirt/types.go
@@ -26,6 +26,7 @@ import (
 
 const (
 	OvirtIdAnnotationKey = "VmId"
+	ProviderIDPrefix     = "ovirt://"
 )
 
 // ActuatorParams holds parameter information for Actuator


### PR DESCRIPTION
This patch makes machine and node provider ID the same,
So nodes will not get marked as unregistered by the autoscaler[1]

[1]
https://github.com/kubernetes/autoscaler/blob/fde90dee450cb4626d4d683a83e623af1753c075/cluster-autoscaler/clusterstate/clusterstate.go#L968-L985
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/clusterapi_nodegroup.go#L211-L214

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>