### PR TITLE
Bug 1898655: Node deleted in OCP should cause the Machine to go into …

### DIFF
--- a/pkg/cloud/ovirt/clients/machineservice.go
+++ b/pkg/cloud/ovirt/clients/machineservice.go
@@ -256,7 +256,6 @@ func (is *InstanceService) GetVm(machine machinev1.Machine) (instance *Instance,
 	}
 	instance, err = is.GetVmByName()
 	return instance, err
-
 }
 
 func (is *InstanceService) GetVmByID(resourceId string) (instance *Instance, err error) {

--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -151,7 +151,8 @@ func (actuator *OvirtActuator) Exists(_ context.Context, machine *machinev1.Mach
 	}
 	vm, err := machineService.GetVm(*machine)
 	if err != nil {
-		return false, err
+		klog.Warningf("oVirt VM %s does not exist", machine.Name)
+		return false, nil
 	}
 	return vm != nil, err
 }


### PR DESCRIPTION
When a node is deleted from our infrastructure but the machine object is still present then the machine controller should move the node into Faild Phase.
See [link](https://github.com/openshift/enhancements/blob/master/enhancements/machine-api/machine-instance-lifecycle.md#failed
) for more information

Signed-off-by: Gal-Zaidman <gzaidman@redhat.com>