### PR TITLE
Bug 1931215: Add support for affinity group

### DIFF
--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -72,6 +72,10 @@ type OvirtMachineProviderSpec struct {
 	// All network interfaces from the template are discarded and new ones will
 	// be created, unless the list is empty or nil
 	NetworkInterfaces []*NetworkInterface `json:"network_interfaces,omitempty"`
+
+	// VMAffinityGroup contains the name of the OpenShift cluster affinity groups
+	// It will be used to add the newly created machine to the affinity groups
+	AffinityGroupsNames []string `json:"affinity_groups_names,omitempty`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)


### PR DESCRIPTION
This commit adds logic to handle affinity groups on machine creation.
We now expose logic for adding a created VM to existing affinity groups by adding a field for affinity groups in the machine spec.
This means that when you create a machine set you can decide that all the VMs will join existing affinity groups in the cluster.

What is not supported:
1. Adding the machine to an affinity group that is not in the cluster, meaning that if the affinity group doesn't exist when the machine is created then it will not be added the group - even later.
2. Updating the field of the machine is not supported, if you update the field on an existing machine nothing will happen.
3. Creating an affinity group - the machine will not create/delete affinity groups.