### PR TITLE
Bug 1912567: handle node removal from oVirt

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -46,6 +46,7 @@ var (
 	leaseDuration = 120 * time.Second
 	renewDeadline = 110 * time.Second
 	retryPeriod   = 20 * time.Second
+	syncPeriod    = 10 * time.Minute
 )
 
 func main() {
@@ -104,8 +105,9 @@ func main() {
 		LeaderElectionNamespace: *leaderElectResourceNamespace,
 		LeaderElectionID:        "cluster-api-provider-ovirt-leader",
 		LeaseDuration:           leaderElectLeaseDuration,
-		MetricsBindAddress:      *metricsAddr,
 		HealthProbeBindAddress:  *healthAddr,
+		SyncPeriod:              &syncPeriod,
+		MetricsBindAddress:      *metricsAddr,
 		// Slow the default retry and renew election rate to reduce etcd writes at idle: BZ 1858400
 		RetryPeriod:   &retryPeriod,
 		RenewDeadline: &renewDeadline,

--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -134,6 +134,7 @@ func (actuator *OvirtActuator) Create(_ context.Context, machine *machinev1.Mach
 }
 
 func (actuator *OvirtActuator) Exists(_ context.Context, machine *machinev1.Machine) (bool, error) {
+	klog.Infof("Checking machine %v exists.\n", machine.Name)
 	providerSpec, err := ovirtconfigv1.ProviderSpecFromRawExtension(machine.Spec.ProviderSpec.Value)
 	if err != nil {
 		return false, actuator.handleMachineError(machine, apierrors.InvalidMachineConfiguration(

--- a/pkg/cloud/ovirt/providerIDcontroller/providerIDController.go
+++ b/pkg/cloud/ovirt/providerIDcontroller/providerIDController.go
@@ -56,13 +56,13 @@ func (r *providerIDReconciler) Reconcile(request reconcile.Request) (reconcile.R
 			// Node doesn't exist in oVirt platform, deleting node
 			r.log.Info(
 				"Deleting Node from cluster since it has been removed from the oVirt engine",
-				"node",request.NamespacedName)
+				"node", request.NamespacedName)
 			if err := r.client.Delete(context.Background(), &node); err != nil {
-				r.log.Error(err, "Error deleting node: %v", "VM name", node.Name)
+				return reconcile.Result{}, fmt.Errorf("Error deleting node: %v, error is: %v", node.Name, err)
 			}
 		}
 		return reconcile.Result{}, nil
-	}else {
+	} else {
 		r.log.Info("spec.ProviderID is empty, fetching from ovirt", "node", request.NamespacedName)
 		node.Spec.ProviderID = ovirt.ProviderIDPrefix + id
 		err = r.client.Update(context.Background(), &node)


### PR DESCRIPTION
Removing a VM from the RHV infrastructure is a 2 step process:
1. Shut the VM down.
2. Once the VM is in "Down" state only then you can remove it.

When the VM is being shut down then the Exist function is being called but it successfully finds the VM and returns ok - which is what expected since the VM can be down for various reasons and we don't want to move the VM into a Failed Phase at that point.
Then when you remove the machine from oVirt then the Exist function is not being called, which also makes sense since there is no OCP event to trigger that.

This fix:
1. requeue the node reconcile if the instance is in "Down" state, which will make the providerIdController to check if the VM exists every minute.
2. adds a SyncPeriod to the machine controller to reconcile all machines each 10m, this is aligned with other platforms and after a discussion with the machine API team