### PR TITLE
Bug 1920905: extract node machine ipaddress from the engine instead using DNS .

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.15
 
 require (
 	github.com/go-logr/logr v0.3.0
+	github.com/go-logr/zapr v0.2.0 // indirect
+	github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
 	github.com/openshift/machine-api-operator v0.2.1-0.20210104142355-8e6ae0acdfcf
 	github.com/ovirt/go-ovirt v0.0.0-20210112072624-e4d3b104de71
 	github.com/pkg/errors v0.9.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -33,6 +33,7 @@ github.com/ghodss/yaml
 ## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.2.0
+## explicit
 github.com/go-logr/zapr
 # github.com/go-openapi/jsonpointer v0.19.3
 github.com/go-openapi/jsonpointer
@@ -108,6 +109,7 @@ github.com/modern-go/reflect2
 # github.com/openshift/api v0.0.0-20201216151826-78a19e96f9eb
 github.com/openshift/api/config/v1
 # github.com/openshift/client-go v0.0.0-20201214125552-e615e336eb49
+## explicit
 github.com/openshift/client-go/config/clientset/versioned
 github.com/openshift/client-go/config/clientset/versioned/scheme
 github.com/openshift/client-go/config/clientset/versioned/typed/config/v1


### PR DESCRIPTION
DNS lookup was a temp solution until qemu-agent will be integrated into  RHCOS,
this change removes DNS lookup and replaces it with oVirt SDK call for the node IP address extraction.

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>