### PR TITLE
Bug 1948963: add support for hugepages

### DIFF
--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -81,6 +81,10 @@ type OvirtMachineProviderSpec struct {
 	// and NUMA including pinning to the host for the instance.
 	// One of "disabled, existing, adjust"
 	AutoPinningPolicy string `json:"auto_pinning_policy,omitempty"`
+
+	// Hugepages is the size of a VM's hugepages to use in KiBs.
+	// Only 2048 and 1048576 supported.
+	Hugepages int32 `json:"hugepages,omitempty"`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)

--- a/pkg/cloud/ovirt/clients/machineservice.go
+++ b/pkg/cloud/ovirt/clients/machineservice.go
@@ -140,6 +140,16 @@ func (is *InstanceService) InstanceCreate(
 			vmBuilder.PlacementPolicy(placementPolicy)
 		}
 	}
+	if providerSpec.Hugepages > 0 {
+		customProp, err := ovirtsdk.NewCustomPropertyBuilder().
+			Name("hugepages").
+			Value(fmt.Sprint(providerSpec.Hugepages)).
+			Build()
+		if err != nil {
+			return nil, err
+		}
+		vmBuilder.CustomPropertiesOfAny(customProp)
+	}
 
 	vm, err := vmBuilder.Build()
 	if err != nil {

--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -451,6 +451,9 @@ func (actuator *OvirtActuator) validateMachine(machine *machinev1.Machine, confi
 			return apierrors.InvalidMachineConfiguration(fmt.Sprintf("%s", err))
 		}
 	}
+	if err := validateHugepages(config.Hugepages); err != nil {
+		return apierrors.InvalidMachineConfiguration(fmt.Sprintf("%s", err))
+	}
 	return nil
 }
 
@@ -492,6 +495,22 @@ func validateVirtualMachineType(vmtype string) *apierrors.MachineError {
 			"error creating oVirt instance: The machine type must "+
 				"be one of the following options: "+
 				"server, high_performance or desktop. The value: %s is not valid", vmtype)
+	}
+	return nil
+}
+
+// validateHugepages execute validation regarding the Virtual Machine hugepages
+// custom property (2048, 1048576).
+// Returns: nil or error
+func validateHugepages(value int32) error {
+	switch value {
+	case 0, 2048, 1048576:
+		return nil
+	default:
+		return fmt.Errorf(
+			"error creating oVirt instance: The machine `hugepages` custom property must " +
+				"be one of the following options: 2048, 1048576. " +
+				"The value: %d is not valid", value)
 	}
 	return nil
 }


### PR DESCRIPTION
This patch will add the hugepages configuration for VMs. It will add the
value to the VM custom property upon creation, letting the VM use the
hugepages feature. There are two option for this settings: `2048` (2
MiB) and `1048576` (1 GiB).