### PR TITLE
Bug 1972747: allow auto pinning new names

### DIFF
--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -79,7 +79,7 @@ type OvirtMachineProviderSpec struct {
 
 	// AutoPinningPolicy defines the policy to automatically set the CPU
 	// and NUMA including pinning to the host for the instance.
-	// One of "disabled, existing, adjust"
+	// One of "none, resize_and_pin"
 	AutoPinningPolicy string `json:"auto_pinning_policy,omitempty"`
 
 	// Hugepages is the size of a VM's hugepages to use in KiBs.

--- a/pkg/cloud/ovirt/clients/machineservice.go
+++ b/pkg/cloud/ovirt/clients/machineservice.go
@@ -122,7 +122,7 @@ func (is *InstanceService) InstanceCreate(
 
 	isAutoPinning := false
 	if providerSpec.AutoPinningPolicy != "" {
-		autoPinningPolicy := ovirtsdk.AutoPinningPolicy(providerSpec.AutoPinningPolicy)
+		autoPinningPolicy := mapAutoPinningPolicy(providerSpec.AutoPinningPolicy)
 
 		// if we have a policy, we need to set the pinning to all the hosts in the cluster.
 		if autoPinningPolicy != ovirtsdk.AUTOPINNINGPOLICY_DISABLED {
@@ -187,7 +187,7 @@ func (is *InstanceService) InstanceCreate(
 	}
 
 	if isAutoPinning {
-		err = is.handleAutoPinning(vmID, ovirtsdk.AutoPinningPolicy(providerSpec.AutoPinningPolicy))
+		err = is.handleAutoPinning(vmID, mapAutoPinningPolicy(providerSpec.AutoPinningPolicy))
 		if err != nil {
 			klog.Errorf("updating the VM (%s) with auto pinning policy failed! %v", vmID, err)
 		}
@@ -487,4 +487,15 @@ func (is *InstanceService) handleAutoPinning(id string, autoPinningPolicy ovirts
 		return errors.Errorf("failed to set the auto pinning policy on the VM!, %v", err)
 	}
 	return nil
+}
+
+func mapAutoPinningPolicy(policy string) ovirtsdk.AutoPinningPolicy {
+	switch policy {
+	case "none":
+		return ovirtsdk.AUTOPINNINGPOLICY_DISABLED
+	case "resize_and_pin":
+		return ovirtsdk.AUTOPINNINGPOLICY_ADJUST
+	default:
+		return ovirtsdk.AUTOPINNINGPOLICY_DISABLED
+	}
 }

--- a/pkg/cloud/ovirt/machine/actuator.go
+++ b/pkg/cloud/ovirt/machine/actuator.go
@@ -551,17 +551,18 @@ func (actuator *OvirtActuator) autoPinningSupported(machine *machinev1.Machine, 
 }
 
 // validateAutPinningPolicyValue execute validations regarding the
-// Virtual Machine auto pinning policy (disabled, existing, adjust).
+// Virtual Machine auto pinning policy (none, resize_and_pin).
 // Returns: nil or error
 func validateAutPinningPolicyValue(autopinningpolicy string) error {
 	switch autopinningpolicy {
-	case "disabled", "existing", "adjust":
+	case "none", "resize_and_pin":
 		return nil
 	default:
 		return fmt.Errorf(
 			"error creating oVirt instance: The machine auto pinning policy must "+
 				"be one of the following options: "+
-				"disabled, existing or adjust. The value: %s is not valid", autopinningpolicy)
+				"none or resize_and_pin. " +
+				"The value: %s is not valid", autopinningpolicy)
 	}
 }
 


### PR DESCRIPTION
Since ovirt 4.4.7, ovirt changed the auto pinning policies naming(UI).
This patch will allow using the new names to align with it. The
previous names are staying to support backward compatibilty.