### PR TITLE
Updated owners because of GitHub account change

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
 approvers:
-  - janoszen
+  - janosdebugs
   - bennyz
   - Gal-Zaidman
   - eslutsky


### PR DESCRIPTION
This PR updates my nick in the owners file because of my recent GitHub account change.