### PR TITLE
Bug 1984481: correct IPAddress detection for OVNKubernetes

### DIFF
--- a/pkg/clients/ovirt/impl.go
+++ b/pkg/clients/ovirt/impl.go
@@ -359,7 +359,7 @@ func (is *ovirtClient) FindVirtualMachineIP(id string, excludeAddr map[string]in
 		return "", fmt.Errorf("cannot find NICs for vmId: %s", id)
 	}
 
-	var nicRegex = regexp.MustCompile(`^(eth|en).*`)
+	var nicRegex = regexp.MustCompile(`^(eth|en|br\-ex).*`)
 
 	for _, reportedDevice := range reportedDeviceSlice.Slice() {
 		nicName, _ := reportedDevice.Name()


### PR DESCRIPTION
when installing with networkType set to OVNKubernetes
external IPAddress Couldnt be detected, causing
master/worker VMs stuck in Provisioned state.