### PR TITLE
Bug 2056454: Preallocated disks for OCP nodes

### DIFF
--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -89,9 +89,20 @@ type OvirtMachineProviderSpec struct {
 	// GuaranteedMemoryMB is the size of a VM's guaranteed memory in MiBs.
 	GuaranteedMemoryMB int32 `json:"guaranteed_memory_mb,omitempty"`
 
-	// PreallocatedDisks indicates that the disks on this machine should be preallocated instead of using thin
-	// provisioning.
-	PreallocatedDisks bool `json:"preallocated_disks,omitempty"`
+	// Clone makes sure that the disks are cloned from the template and are not linked.
+	// Defaults to false.
+	// +optional
+	Clone *bool `json:"clone,omitempty"`
+
+	// Sparse indicates that sparse provisioning should not be used and disks should be preallocated.
+	// Defaults to false.
+	// +optional
+	Sparse *bool `json:"sparse,omitempty"`
+
+	// Format is the disk format that the disks are in. Can be "cow" or "raw". "raw" disables several features that
+	// may be needed, such as incremental backups. Defaults to "cow".
+	// +optional
+	Format string `json:"format,omitempty"`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)

--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -95,7 +95,7 @@ type OvirtMachineProviderSpec struct {
 	Clone *bool `json:"clone,omitempty"`
 
 	// Sparse indicates that sparse provisioning should not be used and disks should be preallocated.
-	// Defaults to false.
+	// Defaults to true.
 	// +optional
 	Sparse *bool `json:"sparse,omitempty"`
 

--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -88,6 +88,10 @@ type OvirtMachineProviderSpec struct {
 
 	// GuaranteedMemoryMB is the size of a VM's guaranteed memory in MiBs.
 	GuaranteedMemoryMB int32 `json:"guaranteed_memory_mb,omitempty"`
+
+	// PreallocatedDisks indicates that the disks on this machine should be preallocated instead of using thin
+	// provisioning.
+	PreallocatedDisks bool `json:"preallocated_disks,omitempty"`
 }
 
 // CPU defines the VM cpu, made of (Sockets * Cores * Threads)

--- a/pkg/apis/ovirtprovider/v1beta1/types.go
+++ b/pkg/apis/ovirtprovider/v1beta1/types.go
@@ -90,7 +90,11 @@ type OvirtMachineProviderSpec struct {
 	GuaranteedMemoryMB int32 `json:"guaranteed_memory_mb,omitempty"`
 
 	// Clone makes sure that the disks are cloned from the template and are not linked.
-	// Defaults to false.
+	// Defaults to true for high performance and server VM types, false for desktop types.
+	//
+	// Note: this option is not documented in the OpenShift documentation. This is intentional as it has sane defaults
+	// that shouldn't be changed unless needed for debugging or resolving issues in cooperation with Red Hat support.
+	//
 	// +optional
 	Clone *bool `json:"clone,omitempty"`
 
@@ -101,6 +105,7 @@ type OvirtMachineProviderSpec struct {
 
 	// Format is the disk format that the disks are in. Can be "cow" or "raw". "raw" disables several features that
 	// may be needed, such as incremental backups. Defaults to "cow".
+	// +kubebuilder:validation:Enum="";raw;cow
 	// +optional
 	Format string `json:"format,omitempty"`
 }

--- a/pkg/clients/ovirt/impl.go
+++ b/pkg/clients/ovirt/impl.go
@@ -154,6 +154,12 @@ func (is *ovirtClient) CreateVMByMachine(
 	addRequest := is.connection.SystemService().VmsService().Add()
 	if providerSpec.Clone != nil {
 		addRequest.Clone(*providerSpec.Clone)
+	} else {
+		if providerSpec.VMType == string(ovirtsdk.VMTYPE_DESKTOP) {
+			addRequest.Clone(false)
+		} else {
+			addRequest.Clone(true)
+		}
 	}
 	response, err := addRequest.Vm(vm).Send()
 	if err != nil {

--- a/pkg/clients/ovirt/impl.go
+++ b/pkg/clients/ovirt/impl.go
@@ -12,11 +12,12 @@ import (
 	"time"
 
 	machinev1 "github.com/openshift/api/machine/v1beta1"
-	ovirtconfigv1 "github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
 	"github.com/openshift/machine-api-operator/pkg/util"
 	ovirtsdk "github.com/ovirt/go-ovirt"
 	"github.com/pkg/errors"
 	"k8s.io/klog"
+
+	ovirtconfigv1 "github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
 )
 
 var _ Client = (*ovirtClient)(nil)
@@ -116,16 +117,30 @@ func (is *ovirtClient) CreateVMByMachine(
 		}
 		vmBuilder.CustomPropertiesOfAny(customProp)
 	}
-	if providerSpec.PreallocatedDisks {
+	if providerSpec.Sparse != nil || providerSpec.Format != "" {
 		templateDiskAttachments, err := is.connection.SystemService().TemplatesService().TemplateService(providerSpec.TemplateName).DiskAttachmentsService().List().Send()
 		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to fetch template %s disk attachments from oVirt Engine", providerSpec.TemplateName))
+			return nil, errors.Wrap(
+				err,
+				fmt.Sprintf(
+					"failed to fetch template %s disk attachments from oVirt Engine",
+					providerSpec.TemplateName,
+				),
+			)
 		}
 		diskAttachments := []ovirtsdk.DiskAttachmentBuilder{}
 		for _, tplAttachedDisk := range templateDiskAttachments.MustAttachments().Slice() {
-			diskAttachments = append(diskAttachments, *ovirtsdk.NewDiskAttachmentBuilder().DiskBuilder(
-				ovirtsdk.NewDiskBuilder().Id(tplAttachedDisk.MustId()).Sparse(false).Format(ovirtsdk.DISKFORMAT_RAW),
-			))
+			diskBuilder := ovirtsdk.NewDiskBuilder().Id(tplAttachedDisk.MustId())
+			if providerSpec.Sparse != nil {
+				diskBuilder.Sparse(*providerSpec.Sparse)
+			}
+			if providerSpec.Format != "" {
+				diskBuilder.Format(ovirtsdk.DiskFormat(providerSpec.Format))
+			}
+
+			diskAttachments = append(
+				diskAttachments, *ovirtsdk.NewDiskAttachmentBuilder().DiskBuilder(diskBuilder),
+			)
 		}
 		vmBuilder.DiskAttachmentsBuilderOfAny(diskAttachments...)
 	}
@@ -136,7 +151,11 @@ func (is *ovirtClient) CreateVMByMachine(
 	}
 
 	klog.Infof("creating VM: %v", vm.MustName())
-	response, err := is.connection.SystemService().VmsService().Add().Vm(vm).Send()
+	addRequest := is.connection.SystemService().VmsService().Add()
+	if providerSpec.Clone != nil {
+		addRequest.Clone(*providerSpec.Clone)
+	}
+	response, err := addRequest.Vm(vm).Send()
 	if err != nil {
 		klog.Errorf("Failed creating VM %v", err)
 		return nil, errors.Wrap(err, "error creating VM")


### PR DESCRIPTION
This change implements [RFE 2035334](https://bugzilla.redhat.com/show_bug.cgi?id=2035334), which enables provisioning OCP nodes with preallocated disks.
