### PR TITLE
Bug 2077597: bump go-ovirt-client to v1.0.0-alpha4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/openshift/api v0.0.0-20211025104849-a11323ccb6ea
 	github.com/openshift/client-go v0.0.0-20211025111749-96ca2abfc56c
 	github.com/openshift/machine-api-operator v0.2.1-0.20211111133920-c8bba3e64310
-	github.com/ovirt/go-ovirt-client v1.0.0-alpha3
+	github.com/ovirt/go-ovirt-client v1.0.0-alpha4
 	github.com/ovirt/go-ovirt-client-log-klog v1.0.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.22.1
@@ -63,7 +63,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/onsi/gomega v1.14.0 // indirect
-	github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db // indirect
+	github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c // indirect
 	github.com/ovirt/go-ovirt-client-log/v2 v2.2.0 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -547,8 +547,12 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/operator-framework/operator-sdk v0.5.1-0.20190301204940-c2efe6f74e7b/go.mod h1:iVyukRkam5JZa8AnjYf+/G3rk7JI1+M6GsU0sq0B9NA=
 github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db h1:ahvAlEurj4TF1SExDJHNeqknQC8lAwnZEPLyZJuRyd0=
 github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
+github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c h1:jXRFpl7+W0YZj/fghoYuE4vJWW/KeQGvdrhnRwRGtAY=
+github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client v1.0.0-alpha3 h1:JPBDjApMN7EZFnVBdUasTCdiDS7/lGzSvF+AN0ZF56I=
 github.com/ovirt/go-ovirt-client v1.0.0-alpha3/go.mod h1:OkR+/CC42lprXXzml/nTDPYzWTiYePvuaN2Kb2xeLr0=
+github.com/ovirt/go-ovirt-client v1.0.0-alpha4 h1:xI+fBHq6RhSR8WuEbljnTZwREchjbuJzgXSKZgpcRdI=
+github.com/ovirt/go-ovirt-client v1.0.0-alpha4/go.mod h1:Ckyo4Px2sVCW7oVZXSxFLW/Astje+y1aHjKIh7+8fow=
 github.com/ovirt/go-ovirt-client-log-klog v1.0.0 h1:xXG2M9FQifMATM5tlzyIA7qdQtcQ8P1kBoTdTt4iJGY=
 github.com/ovirt/go-ovirt-client-log-klog v1.0.0/go.mod h1:lWAyf9bu9+AkS+PKr0J2auzCsxLixDuTeYHhvLtpcLY=
 github.com/ovirt/go-ovirt-client-log/v2 v2.1.0/go.mod h1:mDoU3KIwftpsgZGzXGk5d2UEJYTY0bYMfg/GwPapXL0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -178,10 +178,10 @@ github.com/openshift/machine-api-operator/pkg/controller/machine
 github.com/openshift/machine-api-operator/pkg/metrics
 github.com/openshift/machine-api-operator/pkg/util
 github.com/openshift/machine-api-operator/pkg/util/conditions
-# github.com/ovirt/go-ovirt v0.0.0-20210809163552-d4276e35d3db
+# github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c
 ## explicit; go 1.15
 github.com/ovirt/go-ovirt
-# github.com/ovirt/go-ovirt-client v1.0.0-alpha3
+# github.com/ovirt/go-ovirt-client v1.0.0-alpha4
 ## explicit; go 1.16
 github.com/ovirt/go-ovirt-client
 # github.com/ovirt/go-ovirt-client-log-klog v1.0.0


### PR DESCRIPTION
adding proxies support to the SDK connection

Signed-off-by: Evgeny Slutsky <eslutsky@redhat.com>