### PR TITLE
Disable memory ballooning in high perf workers

### DIFF
--- a/pkg/actuators/machine/actuator_functional_test.go
+++ b/pkg/actuators/machine/actuator_functional_test.go
@@ -144,6 +144,12 @@ func TestActuator(t *testing.T) {
 				if *createdVM.CPU().Mode() != ovirtclient.CPUModeHostPassthrough {
 					t.Errorf("Expected CPU mode to be Host Pass-Through for high performance VM")
 				}
+
+				// check memory ballooning
+				if createdVM.MemoryPolicy().Ballooning() {
+					t.Errorf("Expected memory ballooning to be disabled for high performance VM")
+
+				}
 			},
 		},
 	}

--- a/pkg/actuators/machine/machine.go
+++ b/pkg/actuators/machine/machine.go
@@ -192,6 +192,10 @@ func (ms *machineScope) create() error {
 		cpuMode = cpuMode.MustWithMode(ovirtC.CPUModeHostPassthrough)
 		optionalVMParams = optionalVMParams.MustWithCPU(cpuMode)
 
+		memPolicy := ovirtC.NewMemoryPolicyParameters()
+		memPolicy = memPolicy.MustWithBallooning(false)
+		optionalVMParams = optionalVMParams.WithMemoryPolicy(memPolicy)
+
 	}
 
 	optionalPlacementPolicy = optionalPlacementPolicy.MustWithAffinity(vmAffinity)


### PR DESCRIPTION
Fixes: https://issues.redhat.com/browse/OCPRHV-784