### PR TITLE
added Dockerfile for executing tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,23 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
+
+WORKDIR /go/cluster-api-provider-ovirt
+COPY . .
+
+# functional testing
+RUN sh ./hack/fetch-envtest-tools.sh
+RUN mv ./hack/kubebuilder /usr/local/
+RUN export PATH=$PATH:/usr/local/kubebuilder/bin
+
+ENTRYPOINT [ "make", "test" ]


### PR DESCRIPTION
This PR adds a Dockerfile containing the necessary tooling for execution of functional/integration tests. 

It is triggered via: https://github.com/openshift/release/pull/30441