### PR TITLE
enable headless for high performance VMs

### DIFF
--- a/pkg/actuators/machine/actuator_functional_test.go
+++ b/pkg/actuators/machine/actuator_functional_test.go
@@ -106,6 +106,14 @@ func TestActuator(t *testing.T) {
 				if createdVM.SoundcardEnabled() {
 					t.Errorf("Expected soundcard to be disabled for high performance VM")
 				}
+
+				graphicsConsoles, err := createdVM.ListGraphicsConsoles()
+				if err != nil {
+					t.Errorf("Unexpected error getting graphics consoles: %v", err)
+				}
+				if len(graphicsConsoles) > 0 {
+					t.Errorf("Expected headless mode, but found %d graphics consoles", len(graphicsConsoles))
+				}
 			},
 		},
 	}


### PR DESCRIPTION
This PR fixes [OCPRHV-786](https://issues.redhat.com/browse/OCPRHV-786) by adding a check for `high_performance` of the VM type after VM creation and removing all graphics consoles (thereby enabling headless mode).