### PR TITLE
set serial console enabled for high performance VMs

### DIFF
--- a/pkg/actuators/machine/actuator_functional_test.go
+++ b/pkg/actuators/machine/actuator_functional_test.go
@@ -103,16 +103,23 @@ func TestActuator(t *testing.T) {
 				}
 			},
 			verify: func(inputSpec *machinev1.Machine, createdVM ovirtclient.VM, helper ovirtclient.TestHelper) {
+				// check soundcard
 				if createdVM.SoundcardEnabled() {
 					t.Errorf("Expected soundcard to be disabled for high performance VM")
 				}
 
+				// check headless mode - no graphics consoles == headless
 				graphicsConsoles, err := createdVM.ListGraphicsConsoles()
 				if err != nil {
 					t.Errorf("Unexpected error getting graphics consoles: %v", err)
 				}
 				if len(graphicsConsoles) > 0 {
 					t.Errorf("Expected headless mode, but found %d graphics consoles", len(graphicsConsoles))
+				}
+
+				// check serial console
+				if !createdVM.SerialConsole() {
+					t.Errorf("Expected serial console to be enabled for high performance VM")
 				}
 			},
 		},

--- a/pkg/actuators/machine/machine.go
+++ b/pkg/actuators/machine/machine.go
@@ -190,6 +190,7 @@ func (ms *machineScope) create() error {
 	// see: https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#Automatic_High_Performance_Configuration_Settings
 	if ms.machineProviderSpec.VMType == string(ovirtC.VMTypeHighPerformance) {
 		optionalVMParams.WithSoundcardEnabled(false)
+		optionalVMParams.WithSerialConsole(true)
 	}
 
 	instance, err := ms.ovirtClient.CreateVM(ovirtC.ClusterID(clusterId),


### PR DESCRIPTION
This PR fixes [OCPRHV-787](https://issues.redhat.com/browse/OCPRHV-787) by setting the `serial_console` flag to true before creating the VM. 