### PR TITLE
added functional test for automatically updating credentials

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -136,7 +136,7 @@ func main() {
 		Client:             mgr.GetClient(),
 		Scheme:             mgr.GetScheme(),
 		EventRecorder:      mgr.GetEventRecorderFor("ovirtprovider"),
-		OVirtClientFactory: ovirt.NewOvirtClientFactory(mgr.GetClient()),
+		OVirtClientFactory: ovirt.NewOvirtClientFactory(mgr.GetClient(), ovirt.CreateNewOVirtClient),
 	})
 
 	capimachine.AddWithActuator(mgr, machineActuator)

--- a/pkg/controllers/nodeController/nodeController.go
+++ b/pkg/controllers/nodeController/nodeController.go
@@ -101,7 +101,7 @@ func NewNodeController(mgr manager.Manager) *nodeController {
 			Log:    log.Log.WithName("controllers").WithName(controllerName),
 			Client: mgr.GetClient(),
 
-			OVirtClientFactory: common.NewOvirtClientFactory(mgr.GetClient()),
+			OVirtClientFactory: common.NewOvirtClientFactory(mgr.GetClient(), common.CreateNewOVirtClient),
 		},
 	}
 }

--- a/pkg/controllers/providerIDcontroller/providerIDController.go
+++ b/pkg/controllers/providerIDcontroller/providerIDController.go
@@ -108,7 +108,7 @@ func NewProviderIDController(mgr manager.Manager) *providerIDController {
 			Log:    log.Log.WithName("controllers").WithName(controllerName),
 			Client: mgr.GetClient(),
 
-			OVirtClientFactory: common.NewOvirtClientFactory(mgr.GetClient()),
+			OVirtClientFactory: common.NewOvirtClientFactory(mgr.GetClient(), common.CreateNewOVirtClient),
 		},
 	}
 }


### PR DESCRIPTION
This PR adds a functional test to verify that changes in the k8s secrets for the oVirt engine are automatically updated as required by [OCPRHV-599](https://issues.redhat.com/browse/OCPRHV-599). 