### PR TITLE
Improve logging

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,6 +50,8 @@ var (
 )
 
 func main() {
+	flags := parseFlags()
+
 	cfg := config.GetConfigOrDie()
 	if cfg == nil {
 		panic(fmt.Errorf("GetConfigOrDie didn't die and cfg is nil"))
@@ -61,8 +63,6 @@ func main() {
 		Namespace:  utils.NAMESPACE,
 		SecretName: utils.OvirtCloudCredsSecretName,
 	})
-
-	flags := parseFlags()
 
 	log := logz.New().WithName("ovirt-controller-manager")
 	entryLog := log.WithName("entrypoint")
@@ -101,19 +101,12 @@ func main() {
 func healthCheck(cachedOVirtClient ovirt.CachedOVirtClient) func(*http.Request) error {
 	return func(req *http.Request) error {
 		logger := ovirt.NewKLogr("HealthzCheck")
-		logger.Infof("starting healthz check...")
 
-		client, err := cachedOVirtClient.Get()
+		_, err := cachedOVirtClient.Get()
 		if err != nil {
 			logger.Errorf("failed to get ovirt client: %v", err)
 			return err
 		}
-		err = client.Test()
-		if err != nil {
-			logger.Errorf("ovirt client connection test failed: %v", err)
-			return err
-		}
-		logger.Infof("finished healthz check")
 
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20220603133046-984ee5ebedcf
 	github.com/openshift/machine-api-operator v0.2.1-0.20220601192856-d7fb6b5b87ef
 	github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
-	github.com/ovirt/go-ovirt-client/v2 v2.0.0
+	github.com/ovirt/go-ovirt-client/v2 v2.0.1
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0

--- a/go.sum
+++ b/go.sum
@@ -435,8 +435,8 @@ github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c h1:jXRFpl7+W0YZj/fg
 github.com/ovirt/go-ovirt v0.0.0-20220427092237-114c47f2835c/go.mod h1:Zkdj9/rW6eyuw0uOeEns6O3pP5G2ak+bI/tgkQ/tEZI=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0 h1:uvACVHYhYPMkNJrrgWiABcfELB6qoFfsDDUTbpb4Jv4=
 github.com/ovirt/go-ovirt-client-log/v3 v3.0.0/go.mod h1:chKKxCv4lRjxezrTG+EIhkWXGhDAWByglPVXh/iYdnQ=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0 h1:Woewddu0kX7y1VG+h/O4rLWKBqxjSvui3Op+SBEoeuU=
-github.com/ovirt/go-ovirt-client/v2 v2.0.0/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
+github.com/ovirt/go-ovirt-client/v2 v2.0.1 h1:Avznl0vB5kCeOf1Wxg/kWjZ7cr2sIc4sGKwD4T+/C9o=
+github.com/ovirt/go-ovirt-client/v2 v2.0.1/go.mod h1:Zi2RF2khEr+hcr3fCAf6WL7OEoUwUHeWWiob/WcEaDc=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=

--- a/pkg/controller/nodeController.go
+++ b/pkg/controller/nodeController.go
@@ -75,8 +75,9 @@ func (r *nodeController) Reconcile(ctx context.Context, request reconcile.Reques
 	}
 	ovirtClient, err := r.GetoVirtClient()
 	if err != nil {
-		return ResultRequeueDefault(),
-			errors.Wrap(err, "error getting connection to oVirt, requeue")
+		msg := "error getting connection to oVirt, requeuing"
+		r.Log.Errorf(msg+": %v", err)
+		return ResultRequeueDefault(), errors.Wrap(err, msg)
 	}
 
 	vm, err := ovirtClient.GetVMByName(node.Name)

--- a/pkg/controller/providerIDController.go
+++ b/pkg/controller/providerIDController.go
@@ -68,8 +68,9 @@ func (r *providerIDController) Reconcile(ctx context.Context, request reconcile.
 		r.Log.Infof("spec.ProviderID for Node %s is empty, fetching from ovirt", node.Name)
 		id, err := r.fetchOvirtVmID(node.Name)
 		if err != nil {
-			return ResultRequeueDefault(),
-				fmt.Errorf("failed getting VM %s from oVirt requeue: %w", node.Name, err)
+			errMsg := fmt.Errorf("failed getting VM %s from oVirt requeue: %w", node.Name, err)
+			r.Log.Errorf(errMsg.Error())
+			return ResultRequeueDefault(), errMsg
 		}
 		if id == "" {
 			r.Log.Infof("Node %s not found in oVirt", node.Name)

--- a/pkg/ovirt/cachedClient.go
+++ b/pkg/ovirt/cachedClient.go
@@ -24,7 +24,7 @@ type cachedOVirtClient struct {
 
 func NewCachedOVirtClient(name string) *cachedOVirtClient {
 	return &cachedOVirtClient{
-		logger: NewKLogr("cached-cient", name).WithVInfo(0),
+		logger: NewKLogr("cached-client", name).WithVInfo(0),
 		name:   name,
 
 		credentials:      nil,
@@ -53,7 +53,6 @@ func (cachedClient *cachedOVirtClient) buildClient() error {
 	}
 
 	newClient, err := cachedClient.clientCreateFunc(cachedClient.credentials, NewKLogr("cached-client", cachedClient.name, "ovirt"))
-	newClient.Test()
 	if err != nil {
 		cachedClient.client = nil // invalidate current client, will retrigger build
 		return fmt.Errorf("failed to create oVirt client: %v", err)

--- a/pkg/ovirt/clientCreateFunc.go
+++ b/pkg/ovirt/clientCreateFunc.go
@@ -33,6 +33,6 @@ var CreateNewOVirtClient = func(creds *Credentials, logger *KLogr) (ovirtclient.
 		tls,
 		logger,
 		nil,
-		nil,
+		nil, // no verify, will be done when getting cached client
 	)
 }

--- a/pkg/ovirt/logr.go
+++ b/pkg/ovirt/logr.go
@@ -62,7 +62,7 @@ func NewKLogr(names ...string) *KLogr {
 	return &KLogr{
 		logger:   logger,
 		VDebug:   5,
-		VInfo:    3,
+		VInfo:    0,
 		VWarning: 0,
 	}
 }

--- a/vendor/github.com/ovirt/go-ovirt-client/v2/errors.go
+++ b/vendor/github.com/ovirt/go-ovirt-client/v2/errors.go
@@ -15,6 +15,9 @@ type ErrorCode string
 // EAccessDenied signals that the provided credentials for the oVirt engine were incorrect.
 const EAccessDenied ErrorCode = "access_denied"
 
+// EUserAccountLocked signals that the provided user account for the oVirt engine has been locked.
+const EUserAccountLocked ErrorCode = "user_locked"
+
 // ENotAnOVirtEngine signals that the server did not respond with a proper oVirt response.
 const ENotAnOVirtEngine ErrorCode = "not_ovirt_engine"
 
@@ -112,6 +115,8 @@ func (e ErrorCode) CanAutoRetry() bool {
 		return false
 	case EAccessDenied:
 		return false
+	case EUserAccountLocked:
+		return false
 	case ENotAnOVirtEngine:
 		return false
 	case ETLSError:
@@ -141,14 +146,14 @@ func (e ErrorCode) CanAutoRetry() bool {
 //
 // Usage:
 //
-//   if err != nil {
-//     var realErr ovirtclient.EngineError
-//     if errors.As(err, &realErr) {
-//          // deal with EngineError
-//     } else {
-//          // deal with other errors
-//     }
-//   }
+//	if err != nil {
+//	  var realErr ovirtclient.EngineError
+//	  if errors.As(err, &realErr) {
+//	       // deal with EngineError
+//	  } else {
+//	       // deal with other errors
+//	  }
+//	}
 type EngineError interface {
 	error
 
@@ -261,6 +266,7 @@ func wrap(err error, code ErrorCode, format string, args ...interface{}) EngineE
 	}
 }
 
+//nolint:funlen
 func realIdentify(err error) EngineError {
 	var authErr *ovirtsdk.AuthError
 	var notFoundErr *ovirtsdk.NotFoundError
@@ -318,7 +324,11 @@ func realIdentify(err error) EngineError {
 	case errors.As(err, &authErr):
 		fallthrough
 	case strings.Contains(err.Error(), "access_denied"):
-		return wrap(err, EAccessDenied, "access denied, check your credentials")
+		wrappedErr := wrap(err, EAccessDenied, "access denied, check your credentials")
+		if strings.Contains(err.Error(), "user account is disabled or locked") {
+			wrappedErr = wrap(wrappedErr, EUserAccountLocked, "access denied, user account has been locked")
+		}
+		return wrappedErr
 	default:
 		return nil
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -203,7 +203,7 @@ github.com/ovirt/go-ovirt
 # github.com/ovirt/go-ovirt-client-log/v3 v3.0.0
 ## explicit; go 1.16
 github.com/ovirt/go-ovirt-client-log/v3
-# github.com/ovirt/go-ovirt-client/v2 v2.0.0
+# github.com/ovirt/go-ovirt-client/v2 v2.0.1
 ## explicit; go 1.16
 github.com/ovirt/go-ovirt-client/v2
 # github.com/peterbourgon/diskv v2.0.1+incompatible


### PR DESCRIPTION
This PR does a few minor (logging) improvements such as
- fixed logging typo
- logging errors for node- and providerID-controller on failed oVirt connection
- remove second `.Test()` from healthz func
- updating go-ovirt-client
([OCPRHV-695](https://issues.redhat.com/browse/OCPRHV-695))