### PR TITLE
OCPBUGS-6280: Fix swapped CPU socket and thread mapping

### DIFF
--- a/pkg/actuators/machine/machine.go
+++ b/pkg/actuators/machine/machine.go
@@ -444,9 +444,11 @@ func (ms *machineScope) buildOptionalVMParameters(ignition string, templateID ov
 	} else {
 		// Add CPU
 		if ms.machineProviderSpec.CPU != nil {
-			optionalVMParams = optionalVMParams.MustWithCPUParameters(uint(ms.machineProviderSpec.CPU.Cores),
+			optionalVMParams = optionalVMParams.MustWithCPUParameters(
+				uint(ms.machineProviderSpec.CPU.Cores),
+				uint(ms.machineProviderSpec.CPU.Threads),
 				uint(ms.machineProviderSpec.CPU.Sockets),
-				uint(ms.machineProviderSpec.CPU.Threads))
+			)
 		}
 
 		if ms.machineProviderSpec.MemoryMB > 0 {

--- a/pkg/actuators/machine/machine.go
+++ b/pkg/actuators/machine/machine.go
@@ -77,134 +77,20 @@ func (ms *machineScope) create() error {
 	if err != nil {
 		return errors.Wrap(err, "error getting VM ignition")
 	}
-	optionalVMParams := ovirtC.CreateVMParams().MustWithInitializationParameters(string(ignition), ms.machine.Name)
-
-	if ms.machineProviderSpec.VMType != "" {
-		optionalVMParams = optionalVMParams.MustWithVMType(ovirtC.VMType(ms.machineProviderSpec.VMType))
-	}
-	if ms.machineProviderSpec.InstanceTypeId != "" {
-		optionalVMParams = optionalVMParams.MustWithInstanceTypeID(ovirtC.InstanceTypeID(ms.machineProviderSpec.InstanceTypeId))
-	} else {
-		// Add CPU
-		if ms.machineProviderSpec.CPU != nil {
-			optionalVMParams = optionalVMParams.MustWithCPUParameters(uint(ms.machineProviderSpec.CPU.Cores),
-				uint(ms.machineProviderSpec.CPU.Sockets),
-				uint(ms.machineProviderSpec.CPU.Threads))
-		}
-
-		if ms.machineProviderSpec.MemoryMB > 0 {
-			optionalVMParams = optionalVMParams.MustWithMemory(int64(bytesInMB) * int64(ms.machineProviderSpec.MemoryMB))
-		}
-
-		if ms.machineProviderSpec.GuaranteedMemoryMB > 0 {
-			optionalMemoryPolicy := ovirtC.NewMemoryPolicyParameters().MustWithGuaranteed(int64(bytesInMB) * int64(ms.machineProviderSpec.GuaranteedMemoryMB))
-			optionalVMParams = optionalVMParams.WithMemoryPolicy(optionalMemoryPolicy)
-		}
-	}
-
-	optionalPlacementPolicy := ovirtC.NewVMPlacementPolicyParameters()
-	isAutoPinning := ms.machineProviderSpec.AutoPinningPolicy != "" && ms.machineProviderSpec.AutoPinningPolicy != "none"
-	if isAutoPinning {
-		hosts, err := ms.ovirtClient.ListHosts(ovirtC.ContextStrategy(ms.Context))
-		if err != nil {
-			return errors.Wrap(err, "error Listing hosts")
-		}
-		hostIDs := make([]ovirtC.HostID, 0)
-		for _, host := range hosts {
-			if string(host.ClusterID()) == clusterId {
-				hostIDs = append(hostIDs, host.ID())
-			}
-		}
-		if len(hostIDs) > 0 {
-			optionalPlacementPolicy, err = optionalPlacementPolicy.WithHostIDs(hostIDs)
-			if err != nil {
-				return errors.Wrapf(err, "failed to create placement policy parameters with host IDs: %v", hostIDs)
-			}
-		}
-	}
-
-	if ms.machineProviderSpec.Hugepages > 0 {
-		optionalVMParams = optionalVMParams.MustWithHugePages(ovirtC.VMHugePages(ms.machineProviderSpec.Hugepages))
-	}
-
 	// CREATE VM from a template
 	templateName := ms.machineProviderSpec.TemplateName
-
-	temp, err := ms.ovirtClient.GetTemplateByName(templateName, ovirtC.ContextStrategy(ms.Context))
-
+	template, err := ms.ovirtClient.GetTemplateByName(templateName, ovirtC.ContextStrategy(ms.Context))
 	if err != nil {
 		return errors.Wrapf(err, "error finding template name %s.", templateName)
 	}
 
-	// Handle Sparse disks and Format
-	if ms.machineProviderSpec.Sparse != nil || ms.machineProviderSpec.Format != "" {
-		tempDiskAttachment, err := ms.ovirtClient.ListTemplateDiskAttachments(temp.ID(), ovirtC.ContextStrategy(ms.Context))
-		if err != nil {
-			return errors.Wrapf(err, "failed to fetch template %s disk attachments from oVirt Engine",
-				ms.machineProviderSpec.TemplateName)
-		}
-
-		diskParams := []ovirtC.OptionalVMDiskParameters{}
-		for _, diskAttachment := range tempDiskAttachment {
-			diskBuilder, _ := ovirtC.NewBuildableVMDiskParameters(diskAttachment.DiskID())
-			if ms.machineProviderSpec.Sparse != nil {
-				diskBuilder.MustWithSparse(*ms.machineProviderSpec.Sparse)
-			}
-
-			if ms.machineProviderSpec.Format != "" {
-				diskBuilder.MustWithFormat(ovirtC.ImageFormat(ms.machineProviderSpec.Format))
-			}
-
-			diskParams = append(diskParams, diskBuilder)
-		}
-		optionalVMParams = optionalVMParams.MustWithDisks(diskParams)
+	optionalVMParams, err := ms.buildOptionalVMParameters(string(ignition), template.ID())
+	if err != nil {
+		return errors.Wrapf(err, "error building parameters for VM creation")
 	}
-
-	// Handle Disk Clone
-	if ms.machineProviderSpec.Clone != nil {
-		optionalVMParams = optionalVMParams.MustWithClone(*ms.machineProviderSpec.Clone)
-	} else {
-		if ms.machineProviderSpec.VMType == string(ovirtC.VMTypeDesktop) {
-			optionalVMParams = optionalVMParams.MustWithClone(false)
-		} else {
-			optionalVMParams = optionalVMParams.MustWithClone(true)
-		}
-	}
-
-	if ms.machineProviderSpec.StorageDomainId != "" {
-		tempDiskAttachment, err := ms.ovirtClient.ListTemplateDiskAttachments(temp.ID(), ovirtC.ContextStrategy(ms.Context))
-		if err != nil {
-			return errors.Wrapf(err, "failed to fetch template %s disk attachments from oVirt Engine",
-				ms.machineProviderSpec.TemplateName)
-		}
-		optionalVMParams = optionalVMParams.MustWithDisks([]ovirtC.OptionalVMDiskParameters{
-			ovirtC.MustNewBuildableVMDiskParameters(tempDiskAttachment[0].DiskID()).MustWithStorageDomainID(ovirtC.StorageDomainID(ms.machineProviderSpec.StorageDomainId)),
-		})
-	}
-
-	vmAffinity := ovirtC.VMAffinityMigratable
-	// apply high_performance rules
-	// see: https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#Automatic_High_Performance_Configuration_Settings
-	if ms.machineProviderSpec.VMType == string(ovirtC.VMTypeHighPerformance) {
-		vmAffinity = ovirtC.VMAffinityUserMigratable
-		optionalVMParams.WithSoundcardEnabled(false)
-		optionalVMParams.WithSerialConsole(true)
-
-		cpuMode := ovirtC.NewVMCPUParams()
-		cpuMode = cpuMode.MustWithMode(ovirtC.CPUModeHostPassthrough)
-		optionalVMParams = optionalVMParams.MustWithCPU(cpuMode)
-
-		memPolicy := ovirtC.NewMemoryPolicyParameters()
-		memPolicy = memPolicy.MustWithBallooning(false)
-		optionalVMParams = optionalVMParams.WithMemoryPolicy(memPolicy)
-
-	}
-
-	optionalPlacementPolicy = optionalPlacementPolicy.MustWithAffinity(vmAffinity)
-	optionalVMParams = optionalVMParams.WithPlacementPolicy(optionalPlacementPolicy)
 
 	instance, err := ms.ovirtClient.CreateVM(ovirtC.ClusterID(clusterId),
-		temp.ID(),
+		template.ID(),
 		ms.machine.Name,
 		optionalVMParams, ovirtC.ContextStrategy(ms.Context))
 
@@ -294,7 +180,7 @@ func (ms *machineScope) create() error {
 		}
 	}
 
-	if isAutoPinning {
+	if ms.isAutoPinning() {
 		err = ms.ovirtClient.AutoOptimizeVMCPUPinningSettings(instance.ID(), true, ovirtC.ContextStrategy(ms.Context))
 		if err != nil {
 			return err
@@ -544,4 +430,128 @@ func (ms *machineScope) reconcileMachineAnnotations(status string, id string) {
 	}
 	ms.machine.ObjectMeta.Annotations[InstanceStatusAnnotationKey] = status
 	ms.machine.ObjectMeta.Annotations[utils.OvirtIDAnnotationKey] = id
+}
+
+func (ms *machineScope) buildOptionalVMParameters(ignition string, templateID ovirtC.TemplateID) (ovirtC.BuildableVMParameters, error) {
+	optionalVMParams := ovirtC.CreateVMParams()
+	optionalVMParams = optionalVMParams.MustWithInitializationParameters(ignition, ms.machine.Name)
+
+	if ms.machineProviderSpec.VMType != "" {
+		optionalVMParams = optionalVMParams.MustWithVMType(ovirtC.VMType(ms.machineProviderSpec.VMType))
+	}
+	if ms.machineProviderSpec.InstanceTypeId != "" {
+		optionalVMParams = optionalVMParams.MustWithInstanceTypeID(ovirtC.InstanceTypeID(ms.machineProviderSpec.InstanceTypeId))
+	} else {
+		// Add CPU
+		if ms.machineProviderSpec.CPU != nil {
+			optionalVMParams = optionalVMParams.MustWithCPUParameters(uint(ms.machineProviderSpec.CPU.Cores),
+				uint(ms.machineProviderSpec.CPU.Sockets),
+				uint(ms.machineProviderSpec.CPU.Threads))
+		}
+
+		if ms.machineProviderSpec.MemoryMB > 0 {
+			optionalVMParams = optionalVMParams.MustWithMemory(int64(bytesInMB) * int64(ms.machineProviderSpec.MemoryMB))
+		}
+
+		if ms.machineProviderSpec.GuaranteedMemoryMB > 0 {
+			optionalMemoryPolicy := ovirtC.NewMemoryPolicyParameters().MustWithGuaranteed(int64(bytesInMB) * int64(ms.machineProviderSpec.GuaranteedMemoryMB))
+			optionalVMParams = optionalVMParams.WithMemoryPolicy(optionalMemoryPolicy)
+		}
+	}
+
+	optionalPlacementPolicy := ovirtC.NewVMPlacementPolicyParameters()
+	if ms.isAutoPinning() {
+		hosts, err := ms.ovirtClient.ListHosts(ovirtC.ContextStrategy(ms.Context))
+		if err != nil {
+			return nil, errors.Wrap(err, "error Listing hosts")
+		}
+		hostIDs := make([]ovirtC.HostID, 0)
+		for _, host := range hosts {
+			if string(host.ClusterID()) == ms.machineProviderSpec.ClusterId {
+				hostIDs = append(hostIDs, host.ID())
+			}
+		}
+		if len(hostIDs) > 0 {
+			optionalPlacementPolicy, err = optionalPlacementPolicy.WithHostIDs(hostIDs)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to create placement policy parameters with host IDs: %v", hostIDs)
+			}
+		}
+	}
+
+	if ms.machineProviderSpec.Hugepages > 0 {
+		optionalVMParams = optionalVMParams.MustWithHugePages(ovirtC.VMHugePages(ms.machineProviderSpec.Hugepages))
+	}
+
+	// Handle Sparse disks and Format
+	if ms.machineProviderSpec.Sparse != nil || ms.machineProviderSpec.Format != "" {
+		tempDiskAttachment, err := ms.ovirtClient.ListTemplateDiskAttachments(templateID, ovirtC.ContextStrategy(ms.Context))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch template %s disk attachments from oVirt Engine",
+				ms.machineProviderSpec.TemplateName)
+		}
+
+		diskParams := []ovirtC.OptionalVMDiskParameters{}
+		for _, diskAttachment := range tempDiskAttachment {
+			diskBuilder, _ := ovirtC.NewBuildableVMDiskParameters(diskAttachment.DiskID())
+			if ms.machineProviderSpec.Sparse != nil {
+				diskBuilder.MustWithSparse(*ms.machineProviderSpec.Sparse)
+			}
+
+			if ms.machineProviderSpec.Format != "" {
+				diskBuilder.MustWithFormat(ovirtC.ImageFormat(ms.machineProviderSpec.Format))
+			}
+
+			diskParams = append(diskParams, diskBuilder)
+		}
+		optionalVMParams = optionalVMParams.MustWithDisks(diskParams)
+	}
+
+	// Handle Disk Clone
+	if ms.machineProviderSpec.Clone != nil {
+		optionalVMParams = optionalVMParams.MustWithClone(*ms.machineProviderSpec.Clone)
+	} else {
+		if ms.machineProviderSpec.VMType == string(ovirtC.VMTypeDesktop) {
+			optionalVMParams = optionalVMParams.MustWithClone(false)
+		} else {
+			optionalVMParams = optionalVMParams.MustWithClone(true)
+		}
+	}
+
+	if ms.machineProviderSpec.StorageDomainId != "" {
+		tempDiskAttachment, err := ms.ovirtClient.ListTemplateDiskAttachments(templateID, ovirtC.ContextStrategy(ms.Context))
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to fetch template %s disk attachments from oVirt Engine",
+				ms.machineProviderSpec.TemplateName)
+		}
+		optionalVMParams = optionalVMParams.MustWithDisks([]ovirtC.OptionalVMDiskParameters{
+			ovirtC.MustNewBuildableVMDiskParameters(tempDiskAttachment[0].DiskID()).MustWithStorageDomainID(ovirtC.StorageDomainID(ms.machineProviderSpec.StorageDomainId)),
+		})
+	}
+
+	vmAffinity := ovirtC.VMAffinityMigratable
+	// apply high_performance rules
+	// see: https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index?extIdCarryOver=true&sc_cid=701f2000001Css5AAC#Automatic_High_Performance_Configuration_Settings
+	if ms.machineProviderSpec.VMType == string(ovirtC.VMTypeHighPerformance) {
+		vmAffinity = ovirtC.VMAffinityUserMigratable
+		optionalVMParams.WithSoundcardEnabled(false)
+		optionalVMParams.WithSerialConsole(true)
+
+		cpuMode := ovirtC.NewVMCPUParams()
+		cpuMode = cpuMode.MustWithMode(ovirtC.CPUModeHostPassthrough)
+		optionalVMParams = optionalVMParams.MustWithCPU(cpuMode)
+
+		memPolicy := ovirtC.NewMemoryPolicyParameters()
+		memPolicy = memPolicy.MustWithBallooning(false)
+		optionalVMParams = optionalVMParams.WithMemoryPolicy(memPolicy)
+	}
+
+	optionalPlacementPolicy = optionalPlacementPolicy.MustWithAffinity(vmAffinity)
+	optionalVMParams = optionalVMParams.WithPlacementPolicy(optionalPlacementPolicy)
+
+	return optionalVMParams, nil
+}
+
+func (ms *machineScope) isAutoPinning() bool {
+	return ms.machineProviderSpec.AutoPinningPolicy != "" && ms.machineProviderSpec.AutoPinningPolicy != "none"
 }

--- a/pkg/actuators/machine/machine_test.go
+++ b/pkg/actuators/machine/machine_test.go
@@ -60,10 +60,13 @@ func TestMachineScope_BuildOptionalVMParameter(t *testing.T) {
 		verify func(t *testing.T, params ovirtclient.OptionalVMParameters)
 	}{
 		{
-			name: "asfd",
+			name: "verify CPU Topo",
 			setup: func(
 				basicSpec *v1beta1.OvirtMachineProviderSpec,
 				basicClient ovirtclient.Client) {
+				basicSpec.CPU.Cores = 1
+				basicSpec.CPU.Threads = 1
+				basicSpec.CPU.Sockets = 10
 			},
 			verify: func(t *testing.T, params ovirtclient.OptionalVMParameters) {
 				cpuTopo := params.CPU().Topo()
@@ -73,8 +76,8 @@ func TestMachineScope_BuildOptionalVMParameter(t *testing.T) {
 				if cpuTopo.Threads() != 1 {
 					t.Errorf("Expected CPU Threads to be %d, but got %d", 1, cpuTopo.Threads())
 				}
-				if cpuTopo.Sockets() != 8 {
-					t.Errorf("Expected CPU Sockets to be %d, but got %d", 1, cpuTopo.Sockets())
+				if cpuTopo.Sockets() != 10 {
+					t.Errorf("Expected CPU Sockets to be %d, but got %d", 10, cpuTopo.Sockets())
 				}
 			},
 		},

--- a/pkg/actuators/machine/machine_test.go
+++ b/pkg/actuators/machine/machine_test.go
@@ -1,0 +1,138 @@
+//go:build unit
+
+package machine
+
+import (
+	"testing"
+
+	machinev1 "github.com/openshift/api/machine/v1beta1"
+	"github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
+	capoV1Beta1 "github.com/openshift/cluster-api-provider-ovirt/pkg/apis/ovirtprovider/v1beta1"
+	"github.com/openshift/cluster-api-provider-ovirt/pkg/ovirt"
+	ovirtclient "github.com/ovirt/go-ovirt-client/v2"
+	k8sCorev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestMachineScope_IsAutoPinning(t *testing.T) {
+	testcases := []struct {
+		name              string
+		autoPinningPolicy string
+		expected          bool
+	}{
+		{
+			name:              "Empty AutoPinningPolicy should return false",
+			autoPinningPolicy: "",
+			expected:          false,
+		},
+		{
+			name:              "AutoPinningPolicy 'none' should return false",
+			autoPinningPolicy: "none",
+			expected:          false,
+		},
+		{
+			name:              "AutoPinningPolicy 'adjust' should return true",
+			autoPinningPolicy: "adjust",
+			expected:          true,
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			ms := machineScope{
+				machineProviderSpec: &v1beta1.OvirtMachineProviderSpec{
+					AutoPinningPolicy: testcase.autoPinningPolicy,
+				},
+			}
+
+			got := ms.isAutoPinning()
+			if testcase.expected != got {
+				t.Fatalf("Expected AutoPinningPolicy to be %t, but got %t", testcase.expected, got)
+			}
+		})
+	}
+}
+
+func TestMachineScope_BuildOptionalVMParameter(t *testing.T) {
+	testcases := []struct {
+		name   string
+		setup  func(basicSpec *v1beta1.OvirtMachineProviderSpec, basicClient ovirtclient.Client)
+		verify func(t *testing.T, params ovirtclient.OptionalVMParameters)
+	}{
+		{
+			name: "asfd",
+			setup: func(
+				basicSpec *v1beta1.OvirtMachineProviderSpec,
+				basicClient ovirtclient.Client) {
+			},
+			verify: func(t *testing.T, params ovirtclient.OptionalVMParameters) {
+				cpuTopo := params.CPU().Topo()
+				if cpuTopo.Cores() != 1 {
+					t.Errorf("Expected CPU Cores to be %d, but got %d", 1, cpuTopo.Cores())
+				}
+				if cpuTopo.Threads() != 1 {
+					t.Errorf("Expected CPU Threads to be %d, but got %d", 1, cpuTopo.Threads())
+				}
+				if cpuTopo.Sockets() != 8 {
+					t.Errorf("Expected CPU Sockets to be %d, but got %d", 1, cpuTopo.Sockets())
+				}
+			},
+		},
+	}
+
+	for _, testcase := range testcases {
+		t.Run(testcase.name, func(t *testing.T) {
+			helper, err := ovirtclient.NewMockTestHelper(ovirt.NewKLogr("go-ovirt-client"))
+			if err != nil {
+				t.Fatalf("Unexpected error occurred setting up test helper: %v", err)
+			}
+
+			template, err := helper.GetClient().GetBlankTemplate()
+			if err != nil {
+				t.Fatalf("Failed to get blank template: %v", err)
+			}
+			spec := basicMachineProviderSpec(template.Name(), string(helper.GetClusterID()))
+
+			testcase.setup(spec, helper.GetClient())
+
+			ms := machineScope{
+				machineProviderSpec: spec,
+				machine: &machinev1.Machine{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "test-machine",
+					},
+				},
+				ovirtClient: helper.GetClient(),
+			}
+			params, err := ms.buildOptionalVMParameters("", template.ID())
+			if err != nil {
+				t.Fatalf("Unexpected error occurred while building optional VM parameter: %v", err)
+			}
+
+			testcase.verify(t, params)
+		})
+	}
+}
+
+func basicMachineProviderSpec(templateName string, clusterID string) *v1beta1.OvirtMachineProviderSpec {
+	return &v1beta1.OvirtMachineProviderSpec{
+		ClusterId:    clusterID,
+		TemplateName: templateName,
+		Name:         "vm-hello-ovirt",
+		VMType:       "server",
+		MemoryMB:     16348,
+		Format:       "raw",
+		OSDisk:       &capoV1Beta1.Disk{SizeGB: 31},
+		CPU: &capoV1Beta1.CPU{
+			Cores:   1,
+			Threads: 1,
+			Sockets: 8,
+		},
+		UserDataSecret: &k8sCorev1.LocalObjectReference{
+			Name: "ignitionscript",
+		},
+		AutoPinningPolicy:  "",
+		Hugepages:          0,
+		GuaranteedMemoryMB: 10000,
+	}
+}


### PR DESCRIPTION
This PR fixes the swapped thread and socket mapping when creating a VM. It also extracts building the optional VM parameter to a dedicated function and adds a unit test for it. 